### PR TITLE
Support for non mapped accession with taxid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ftputil
 peewee==2.8.1
+psycopg2
 PyMySQL
 nose

--- a/taxadb/accession.py
+++ b/taxadb/accession.py
@@ -19,12 +19,12 @@ def taxid(acc_number_list, db_name, table):
     db.connect()
     _check_table_exists(table)
     with db.atomic():
-            query = table.select().where(table.accession << acc_number_list)
-            for i in query:
-                try:
-                    yield (i.accession, i.taxid.ncbi_taxid)
-                except Taxa.DoesNotExist:
-                    _unmapped_taxid(i.accession)
+        query = table.select().where(table.accession << acc_number_list)
+        for i in query:
+            try:
+                yield (i.accession, i.taxid.ncbi_taxid)
+            except Taxa.DoesNotExist:
+                _unmapped_taxid(i.accession)
     db.close()
 
 
@@ -125,7 +125,7 @@ def _check_table_exists(table):
     Throws `SystemExit` if table does not exist
     """
     if not table.table_exists():
-        print("Table %s does not exists" % (str(table._meta.db_table)), file=sys.stderr)
+        print("Table %s does not exist" % (str(table._meta.db_table)), file=sys.stderr)
         sys.exit(1)
     return True
 
@@ -144,3 +144,4 @@ def _unmapped_taxid(acc, exit=False):
     if exit:
         sys.exit(1)
     return True
+

--- a/taxadb/app.py
+++ b/taxadb/app.py
@@ -131,11 +131,8 @@ def create_db(args):
 
     with db.atomic():
         for table, acc_file in acc_dl_dict.items():
-            # for data_dict in parse.accession2taxid(
-            #                         args.input + '/' + acc_file):
-            #     table.create(**data_dict)
             for table, acc_file in acc_dl_dict.items():
-                for data_dict in parse.accession2taxidyield(
+                for data_dict in parse.accession2taxid(
                                         args.input + '/' + acc_file, args.chunk):
                     table.insert_many(data_dict[0:args.chunk]).execute()
             print('%s: %s added to database' % (table, acc_file))

--- a/taxadb/app.py
+++ b/taxadb/app.py
@@ -131,10 +131,9 @@ def create_db(args):
 
     with db.atomic():
         for table, acc_file in acc_dl_dict.items():
-            for table, acc_file in acc_dl_dict.items():
-                for data_dict in parse.accession2taxid(
-                                        args.input + '/' + acc_file, args.chunk):
-                    table.insert_many(data_dict[0:args.chunk]).execute()
+            for data_dict in parse.accession2taxid(
+                    args.input + '/' + acc_file, args.chunk):
+                table.insert_many(data_dict[0:args.chunk]).execute()
             print('%s: %s added to database' % (table, acc_file))
             print('Creating index for field accession ... ', end="")
             db.create_index(table, ['accession'], unique=True)

--- a/taxadb/app.py
+++ b/taxadb/app.py
@@ -130,6 +130,9 @@ def create_db(args):
                     args.input + '/' + acc_file):
                 table.create(**data_dict)
             print('%s: %s added to database' % (table, acc_file))
+            print('Creating index for field accession ... ', end="")
+            db.create_index(table, ['accession'], unique=True)
+            print('created.')
     print('Sequence: completed')
     db.close()
 

--- a/taxadb/parse.py
+++ b/taxadb/parse.py
@@ -48,25 +48,25 @@ def taxdump(nodes_file, names_file):
     return taxa_info_list
 
 
-def accession2taxid(acc2taxid):
-    """Parse the accession2taxid files. and insert
-    squences in the Sequence table.
+#def accession2taxid(acc2taxid):
+#    """Parse the accession2taxid files. and insert
+#    squences in the Sequence table.
+#
+#    Arguments:
+#    acc2taxid -- input file (gzipped)
+#    """
+#    with gzip.open(acc2taxid, 'rb') as f:
+#        f.readline()  # discard the header
+#        for line in f:
+#            line_list = line.decode().rstrip('\n').split('\t')
+#            data_dict = {
+#                'accession': line_list[0],
+#                'taxid': line_list[2]
+#            }
+#            yield(data_dict)
 
-    Arguments:
-    acc2taxid -- input file (gzipped)
-    """
-    with gzip.open(acc2taxid, 'rb') as f:
-        f.readline()  # discard the header
-        for line in f:
-            line_list = line.decode().rstrip('\n').split('\t')
-            data_dict = {
-                'accession': line_list[0],
-                'taxid': line_list[2]
-            }
-            yield(data_dict)
 
-
-def accession2taxidyield(acc2taxid, chunk):
+def accession2taxid(acc2taxid, chunk):
     """Parses the accession2taxid files and insert sequences in Sequences table(s).
 
     Arguments:


### PR DESCRIPTION
Hi,

First of all, I've found your project very interesting and tried to use it. It works well except some case where an accession number is not mapped to a taxid, see method `_unmapped_taxid`.
So I've made some modifications to your code to try to support this and avoid a stack trace.
I've also tried to speed up a little bit the data loading using `insert_many` when loading other files than `names.dmp` and `nodes.dmp`.
Have a look at the PR and let me know.

Best

Emmanuel